### PR TITLE
Use "implementation" instead of "compile" in Gradle dependencies.

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -3,5 +3,5 @@ repositories{
 }
 
 dependencies {
-    compile 'com.github.scottyab:rootbeer:0.0.8'
+    implementation 'com.github.scottyab:rootbeer:0.0.8'
 }


### PR DESCRIPTION
Fix #10 by updating Gradle dependencies to use "implementation" instead of "compile". This ought to fix build errors while using `cordova-android@11` or later.